### PR TITLE
Add aliases, functions and dns zone to output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -2,3 +2,8 @@ output "cloudfront_url" {
   description = "The CloudFront distrubtion domain name"
   value       = aws_cloudfront_distribution.this.domain_name
 }
+
+output "cloudfront_hosted_zone_id" {
+  description = "The CloudFront Route 53 zone ID"
+  value       = aws_cloudfront_distribution.this.hosted_zone_id
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,12 @@
 #################
 # Configuration #
 #################
+variable "aliases" {
+  type        = list(string)
+  description = "Extra CNAMEs (alternate domain names), if any, for this distribution."
+  default     = []
+}
+
 variable "bucket_domain_name" {
   type        = string
   description = "S3 bucket domain name to serve content from"
@@ -9,6 +15,18 @@ variable "bucket_domain_name" {
 variable "bucket_id" {
   type        = string
   description = "S3 bucket ID to serve content from (used to automatically create the appropriate policy)"
+}
+
+variable "cloudfront_function" {
+  type        = map(any)
+  description = "Provides a CloudFront Function resource." 
+  default     = {}
+}
+
+variable "cloudfront_function_event_type" {
+  type        = string
+  description = "Specific event to trigger the function. Valid values: viewer-request or viewer-respons."
+  default     = "viewer-request"
 }
 
 variable "default_root_object" {


### PR DESCRIPTION
Hi Cloud Platforms. This is an untested draft to implement the following changes.

- `aws_cloudfront_function` - for authorization via JWT
- add `aliases` to `cloud-platform-terraform-cloudfront` - so that we may use a subdomain, enabling us to set a JWT cookie in our app, and have that available to the `aws_cloudfront_function`
- add `function_association` to `aws_cloudfront_distribution.default_cache_behavior`
- add `jwt_secret` input to the CloudFront module, so that it can be available in `aws_cloudfront_function` code like `code = join("\n", [ "const jwtSecret = ${var.jwt_secret};", file("${path.module}/function.js") ]) `. (This secret should also be available to our app). I realise this doensn't require an edit to this codebase.
- add `cloudfront_distribution_hosted_zone_id` output to the CloudFront module, so that it can be used in a route53 A record.

[Slack thread](https://mojdt.slack.com/archives/C57UPMZLY/p1711616686493159)

Please may you review and advise, especially the `function_association` part as my editor hinting is showing an error there.

Thanks in advance.

References.

- [cloudfront_function](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_function)
- [cloudfront_distribution#aliases](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution)
    - [aliases](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#aliases)
    - [function-association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#function-association)
    - [hosted_zone_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#hosted_zone_id)