### PR TITLE
Allow for custom_error_response argument.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ No modules.
 | <a name="input_origin"></a> [origin](#input\_origin) | Origin configuration (origin.connection\_attempts, origin.connection\_timeout) | `map(any)` | `{}` | no |
 | <a name="input_price_class"></a> [price\_class](#input\_price\_class) | Price Class to use | `string` | `"PriceClass_All"` | no |
 | <a name="input_team_name"></a> [team\_name](#input\_team\_name) | Team name | `string` | n/a | yes |
-| <a name="input_trusted_public_keys"></a> [trusted\_public\_keys](#input\_trusted\_public\_keys) | Public key in PEM format. Including --- BEGIN PUBLIC KEY --- and --- END PUBLIC KEY ---. Optional comment. | <pre>list(object({<br>    encoded_key = string<br>    comment     = string<br>    associate   = bool<br>  }))</pre> | `[]` | no |
+| <a name="input_trusted_public_keys"></a> [trusted\_public\_keys](#input\_trusted\_public\_keys) | Public key in PEM format. Including --- BEGIN PUBLIC KEY --- and --- END PUBLIC KEY ---. Optional comment. | <pre>list(object({<br>  encoded_key = string<br>  comment     = string<br>  associate   = bool<br>}))</pre> | `[]` | no |
+| <a name="input_custom_error_response"></a> [custom\_error\_response](#input\_custom\_error\_response) | Custom error response(s) | <pre>list(object({<br>  error_caching_min_ttl = optional(number)<br>  error_code            = number<br>  response_code         = optional(number)<br>  response_page_path    = optional(string)<br>}))</pre> | `[]` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -141,6 +141,17 @@ resource "aws_cloudfront_distribution" "this" {
     ssl_support_method  = var.aliases_cert_arn != null ? "sni-only" : null
   }
 
+  dynamic "custom_error_response" {
+    for_each = [var.custom_error_response]
+
+    content {
+      error_caching_min_ttl = lookup(origin.value, "error_caching_min_ttl", null)
+      error_code            = lookup(origin.value, "error_code", null)
+      response_code         = lookup(origin.value, "response_code", null)
+      response_page_path    = lookup(origin.value, "response_page_path", null)
+    }
+  }
+
 }
 
 ################################

--- a/variables.tf
+++ b/variables.tf
@@ -69,6 +69,17 @@ variable "ip_allow_listing_environment" {
   description = "[Prisoner Content Hub only]: specify the environment name to restrict CloudFront to a preset IP allow-list, either `development`, `staging`, `production`. Leave empty for unrestricted access."
 }
 
+variable "custom_error_response" {
+  type = list(object({
+    error_caching_min_ttl = optional(number)
+    error_code            = number
+    response_code         = optional(number)
+    response_page_path    = optional(string)
+  }))
+  description = "One or more custom error response elements"
+  default     = []
+}
+
 ########
 # Tags #
 ########


### PR DESCRIPTION
This PR allows for an array of `custom_error_response` to be set when using the module.

The argument is referenced in the cloudfront_distribution docs at https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution

I am by no means an expert at tf, please see this PR as a suggestion for your consideration. It may well need iteration, or rewriting as you see fit. It's untested, though I do have a dev namespace where I can run a test provisioning.

The justification for this PR is that my team is serving a static site via CloudFront, currently, when a user needs to login they will a non-user-friendly error message.

After this PR we will be able to set a custom 403 error message telling the uset that they will need to log in to see the content.