### PR TITLE
Allow a list of ordered_cache_behaviors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,21 @@ module "cloudfront" {
   # Ordered cache behaviors (optional)
   enable_ordered_cache_behavior = true # Default is false
 
-  ordered_cache_behavior = {
-    path_pattern = "/images/*"
-    # Optional parameters
-    # cache_policy_id = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" ### CachingDisabled
-  }
+  # A list is evaluated in precedence order - the first matching path_pattern wins.
+  # A single object (rather than a list) is also accepted, for a single behavior.
+  ordered_cache_behavior = [
+    {
+      path_pattern = "/images/*"
+      # Optional parameters
+      # cache_policy_id = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" ### CachingDisabled
+    },
+    {
+      path_pattern    = "/api/*"
+      allowed_methods = ["GET", "HEAD", "OPTIONS"]
+      compress        = false
+      cache_policy_id = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" ### CachingDisabled
+    },
+  ]
 }
 ```
 See the [examples/](examples/) folder for more information.
@@ -99,7 +109,7 @@ No modules.
 | <a name="input_is_production"></a> [is\_production](#input\_is\_production) | Whether this is used for production or not | `string` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace name | `string` | n/a | yes |
 | <a name="input_opt_in_xsiam_logging"></a> [opt\_in\_xsiam\_logging](#input\_opt\_in\_xsiam\_logging) | If set to true, it will send cloudfront logs to an S3 bucket and send them to Cortex XSIAM. | `bool` | `false` | no |
-| <a name="input_ordered_cache_behavior"></a> [ordered\_cache\_behavior](#input\_ordered\_cache\_behavior) | Ordered cache behavior configuration. Must include path\_pattern. Optional: allowed\_methods, cached\_methods, compress, default\_ttl, max\_ttl, min\_ttl, cache\_policy\_id, response\_headers\_policy\_id | `map(any)` | `{}` | no |
+| <a name="input_ordered_cache_behavior"></a> [ordered\_cache\_behavior](#input\_ordered\_cache\_behavior) | Ordered cache behavior configuration, either a single object or a list of them in precedence order. Each must include path\_pattern. Optional: allowed\_methods, cached\_methods, compress, default\_ttl, max\_ttl, min\_ttl, cache\_policy\_id, response\_headers\_policy\_id | `any` | `{}` | no |
 | <a name="input_origin"></a> [origin](#input\_origin) | Origin configuration (origin.connection\_attempts, origin.connection\_timeout) | `map(any)` | `{}` | no |
 | <a name="input_price_class"></a> [price\_class](#input\_price\_class) | Price Class to use | `string` | `"PriceClass_All"` | no |
 | <a name="input_service_area"></a> [service\_area](#input\_service\_area) | The MOJ service area this application supports | `string` | n/a | yes |

--- a/examples/cloudfront.tf
+++ b/examples/cloudfront.tf
@@ -33,9 +33,19 @@ module "cloudfront" {
   # Ordered cache behaviors (optional)
   enable_ordered_cache_behavior = true # Default is false
 
-  ordered_cache_behavior = {
-    path_pattern = "/images/*"
-    # Optional parameters
-    # cache_policy_id = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" ### CachingDisabled
-  }
+  # A list is evaluated in precedence order - the first matching path_pattern wins.
+  # A single object (rather than a list) is also accepted, for a single behavior.
+  ordered_cache_behavior = [
+    {
+      path_pattern = "/images/*"
+      # Optional parameters
+      # cache_policy_id = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" ### CachingDisabled
+    },
+    {
+      path_pattern    = "/api/*"
+      allowed_methods = ["GET", "HEAD", "OPTIONS"]
+      compress        = false
+      cache_policy_id = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" ### CachingDisabled
+    },
+  ]
 }

--- a/main.tf
+++ b/main.tf
@@ -28,6 +28,16 @@ locals {
   encoded_keys_short_hash = [for key in local.encoded_keys_formatted : substr(sha256(key), 0, 8)]
   # Filter out the keys that are associated. This is used to determine if the key group should be created.
   associated_keys_count = length([for key in var.trusted_public_keys : key if key.associate])
+
+  # Ordered cache behaviours, in precedence order.
+  # Either a single behaviour or a list of them is accepted. flatten() recurses into lists but leaves
+  # maps alone, so both shapes normalise to a list without needing to detect which was given.
+  # The enable_ordered_cache_behavior gate is a filter rather than a conditional: the branches of a
+  # conditional must unify to one type, which fails once behaviours differ in their attributes.
+  ordered_cache_behaviors = [
+    for behavior in flatten([var.ordered_cache_behavior]) : behavior
+    if var.enable_ordered_cache_behavior
+  ]
 }
 
 ########################
@@ -113,10 +123,10 @@ resource "aws_cloudfront_distribution" "this" {
   }
 
   dynamic "ordered_cache_behavior" {
-    for_each = var.enable_ordered_cache_behavior ? [var.ordered_cache_behavior] : []
+    for_each = local.ordered_cache_behaviors
 
     content {
-      path_pattern               = try(ordered_cache_behavior.value.path_pattern, ordered_cache_behavior.value["path_pattern"])
+      path_pattern               = ordered_cache_behavior.value.path_pattern
       allowed_methods            = try(ordered_cache_behavior.value.allowed_methods, ["GET", "HEAD", "OPTIONS"])
       cached_methods             = try(ordered_cache_behavior.value.cached_methods, ["GET", "HEAD"])
       compress                   = try(ordered_cache_behavior.value.compress, true)

--- a/variables.tf
+++ b/variables.tf
@@ -52,8 +52,8 @@ variable "default_cache_behavior" {
 }
 
 variable "ordered_cache_behavior" {
-  type        = map(any)
-  description = "Ordered cache behavior configuration. Must include path_pattern. Optional: allowed_methods, cached_methods, compress, default_ttl, max_ttl, min_ttl, cache_policy_id, response_headers_policy_id"
+  type        = any
+  description = "Ordered cache behavior configuration, either a single object or a list of them in precedence order. Each must include path_pattern. Optional: allowed_methods, cached_methods, compress, default_ttl, max_ttl, min_ttl, cache_policy_id, response_headers_policy_id"
   default     = {}
 }
 


### PR DESCRIPTION
We have an S3 bucket and CloudFront distribution where we need to have different behaviours based on 3 file paths.

- A default
- File path 1
- File path 2

---

With the current module we can only set a single `ordered_cache_behavior` that affects a single path.

---

With this proposed change, `ordered_cache_behavior` may be a list, allowing us to have many different behaviours.

The change is backwards compatible, so people who are already using this property, do not need to make any changes.