### PR TITLE
Modify default_cache_behavior and geo_restriction types and parsing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,11 @@ No modules.
 | <a name="input_bucket_id"></a> [bucket\_id](#input\_bucket\_id) | S3 bucket ID to serve content from (used to automatically create the appropriate policy) | `string` | n/a | yes |
 | <a name="input_business_unit"></a> [business\_unit](#input\_business\_unit) | Area of the MOJ responsible for the service | `string` | n/a | yes |
 | <a name="input_custom_error_response"></a> [custom\_error\_response](#input\_custom\_error\_response) | One or more custom error response elements | `list(any)` | `[]` | no |
-| <a name="input_default_cache_behavior"></a> [default\_cache\_behavior](#input\_default\_cache\_behavior) | Default cache behaviour | `map(any)` | `{}` | no |
+| <a name="input_default_cache_behavior"></a> [default\_cache\_behavior](#input\_default\_cache\_behavior) | Default cache behaviour. Optional: allowed\_methods, cached\_methods, compress, default\_ttl, max\_ttl, min\_ttl, cache\_policy\_id, response\_headers\_policy\_id | `any` | `{}` | no |
 | <a name="input_default_root_object"></a> [default\_root\_object](#input\_default\_root\_object) | Object that you want CloudFront to return (for example, index.html) when an end user requests the root URL. | `string` | `null` | no |
 | <a name="input_enable_ordered_cache_behavior"></a> [enable\_ordered\_cache\_behavior](#input\_enable\_ordered\_cache\_behavior) | Whether to enable ordered cache behavior | `bool` | `false` | no |
 | <a name="input_environment_name"></a> [environment\_name](#input\_environment\_name) | Environment name | `string` | n/a | yes |
-| <a name="input_geo_restriction"></a> [geo\_restriction](#input\_geo\_restriction) | Geographical restrictions | `map(any)` | `{}` | no |
+| <a name="input_geo_restriction"></a> [geo\_restriction](#input\_geo\_restriction) | Geographical restrictions. Optional: restriction\_type, locations | `any` | `{}` | no |
 | <a name="input_infrastructure_support"></a> [infrastructure\_support](#input\_infrastructure\_support) | The team responsible for managing the infrastructure. Should be of the form <team-name> (<team-email>) | `string` | n/a | yes |
 | <a name="input_ip_allow_listing_environment"></a> [ip\_allow\_listing\_environment](#input\_ip\_allow\_listing\_environment) | [Prisoner Content Hub only]: specify the environment name to restrict CloudFront to a preset IP allow-list, either `development`, `staging`, `production`. Leave empty for unrestricted access. | `string` | `null` | no |
 | <a name="input_is_production"></a> [is\_production](#input\_is\_production) | Whether this is used for production or not | `string` | n/a | yes |

--- a/examples/cloudfront.tf
+++ b/examples/cloudfront.tf
@@ -38,4 +38,17 @@ module "cloudfront" {
     # Optional parameters
     # cache_policy_id = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" ### CachingDisabled
   }
+
+  # Default cache behavior (optional) - mixes list, bool and number values
+  default_cache_behavior = {
+    allowed_methods = ["GET", "HEAD", "OPTIONS"]
+    compress        = true
+    min_ttl         = 0
+  }
+
+  # Geographical restrictions (optional)
+  geo_restriction = {
+    restriction_type = "whitelist"
+    locations        = ["GB", "IE"]
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -98,16 +98,16 @@ resource "aws_cloudfront_distribution" "this" {
     for_each = [var.default_cache_behavior]
 
     content {
-      allowed_methods            = lookup(default_cache_behavior.value, "allowed_methods", ["GET", "HEAD", "OPTIONS"])
-      cached_methods             = lookup(default_cache_behavior.value, "cached_methods", ["GET", "HEAD"])
-      compress                   = lookup(default_cache_behavior.value, "compress", true)
-      default_ttl                = lookup(default_cache_behavior.value, "default_ttl", 0)
-      max_ttl                    = lookup(default_cache_behavior.value, "max_ttl", 0)
-      min_ttl                    = lookup(default_cache_behavior.value, "min_ttl", 0)
+      allowed_methods            = try(default_cache_behavior.value.allowed_methods, ["GET", "HEAD", "OPTIONS"])
+      cached_methods             = try(default_cache_behavior.value.cached_methods, ["GET", "HEAD"])
+      compress                   = try(default_cache_behavior.value.compress, true)
+      default_ttl                = try(default_cache_behavior.value.default_ttl, 0)
+      max_ttl                    = try(default_cache_behavior.value.max_ttl, 0)
+      min_ttl                    = try(default_cache_behavior.value.min_ttl, 0)
       target_origin_id           = local.target_origin_id
-      viewer_protocol_policy     = "redirect-to-https"                                                                                        # Enforce redirecting HTTP to HTTPS
-      cache_policy_id            = lookup(default_cache_behavior.value, "cache_policy_id", "658327ea-f89d-4fab-a63d-7e88639e58f6")            # 658327ea-f89d-4fab-a63d-7e88639e58f6 is "CachingOptimized"
-      response_headers_policy_id = lookup(default_cache_behavior.value, "response_headers_policy_id", "67f7725c-6f97-4210-82d7-5512b31e9d03") # 67f7725c-6f97-4210-82d7-5512b31e9d03 is "Managed-SecurityHeadersPolicy"
+      viewer_protocol_policy     = "redirect-to-https"                                                                                  # Enforce redirecting HTTP to HTTPS
+      cache_policy_id            = try(default_cache_behavior.value.cache_policy_id, "658327ea-f89d-4fab-a63d-7e88639e58f6")            # 658327ea-f89d-4fab-a63d-7e88639e58f6 is "CachingOptimized"
+      response_headers_policy_id = try(default_cache_behavior.value.response_headers_policy_id, "67f7725c-6f97-4210-82d7-5512b31e9d03") # 67f7725c-6f97-4210-82d7-5512b31e9d03 is "Managed-SecurityHeadersPolicy"
       trusted_key_groups         = local.associated_keys_count > 0 ? [aws_cloudfront_key_group.this[0].id] : null
     }
   }
@@ -149,8 +149,8 @@ resource "aws_cloudfront_distribution" "this" {
       for_each = [var.geo_restriction]
 
       content {
-        restriction_type = lookup(geo_restriction.value, "restriction_type", "none")
-        locations        = lookup(geo_restriction.value, "locations", [])
+        restriction_type = try(geo_restriction.value.restriction_type, "none")
+        locations        = try(geo_restriction.value.locations, [])
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -98,16 +98,16 @@ resource "aws_cloudfront_distribution" "this" {
     for_each = [var.default_cache_behavior]
 
     content {
-      allowed_methods            = try(default_cache_behavior.value.allowed_methods, ["GET", "HEAD", "OPTIONS"])
-      cached_methods             = try(default_cache_behavior.value.cached_methods, ["GET", "HEAD"])
-      compress                   = try(default_cache_behavior.value.compress, true)
-      default_ttl                = try(default_cache_behavior.value.default_ttl, 0)
-      max_ttl                    = try(default_cache_behavior.value.max_ttl, 0)
-      min_ttl                    = try(default_cache_behavior.value.min_ttl, 0)
+      allowed_methods            = lookup(default_cache_behavior.value, "allowed_methods", ["GET", "HEAD", "OPTIONS"])
+      cached_methods             = lookup(default_cache_behavior.value, "cached_methods", ["GET", "HEAD"])
+      compress                   = lookup(default_cache_behavior.value, "compress", true)
+      default_ttl                = lookup(default_cache_behavior.value, "default_ttl", 0)
+      max_ttl                    = lookup(default_cache_behavior.value, "max_ttl", 0)
+      min_ttl                    = lookup(default_cache_behavior.value, "min_ttl", 0)
       target_origin_id           = local.target_origin_id
-      viewer_protocol_policy     = "redirect-to-https"                                                                                  # Enforce redirecting HTTP to HTTPS
-      cache_policy_id            = try(default_cache_behavior.value.cache_policy_id, "658327ea-f89d-4fab-a63d-7e88639e58f6")            # 658327ea-f89d-4fab-a63d-7e88639e58f6 is "CachingOptimized"
-      response_headers_policy_id = try(default_cache_behavior.value.response_headers_policy_id, "67f7725c-6f97-4210-82d7-5512b31e9d03") # 67f7725c-6f97-4210-82d7-5512b31e9d03 is "Managed-SecurityHeadersPolicy"
+      viewer_protocol_policy     = "redirect-to-https"                                                                                        # Enforce redirecting HTTP to HTTPS
+      cache_policy_id            = lookup(default_cache_behavior.value, "cache_policy_id", "658327ea-f89d-4fab-a63d-7e88639e58f6")            # 658327ea-f89d-4fab-a63d-7e88639e58f6 is "CachingOptimized"
+      response_headers_policy_id = lookup(default_cache_behavior.value, "response_headers_policy_id", "67f7725c-6f97-4210-82d7-5512b31e9d03") # 67f7725c-6f97-4210-82d7-5512b31e9d03 is "Managed-SecurityHeadersPolicy"
       trusted_key_groups         = local.associated_keys_count > 0 ? [aws_cloudfront_key_group.this[0].id] : null
     }
   }
@@ -149,8 +149,8 @@ resource "aws_cloudfront_distribution" "this" {
       for_each = [var.geo_restriction]
 
       content {
-        restriction_type = try(geo_restriction.value.restriction_type, "none")
-        locations        = try(geo_restriction.value.locations, [])
+        restriction_type = lookup(geo_restriction.value, "restriction_type", "none")
+        locations        = lookup(geo_restriction.value, "locations", [])
       }
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -46,8 +46,8 @@ variable "enable_ordered_cache_behavior" {
 }
 
 variable "default_cache_behavior" {
-  type        = map(any)
-  description = "Default cache behaviour"
+  type        = any
+  description = "Default cache behaviour. Optional: allowed_methods, cached_methods, compress, default_ttl, max_ttl, min_ttl, cache_policy_id, response_headers_policy_id"
   default     = {}
 }
 
@@ -58,8 +58,8 @@ variable "ordered_cache_behavior" {
 }
 
 variable "geo_restriction" {
-  type        = map(any)
-  description = "Geographical restrictions"
+  type        = any
+  description = "Geographical restrictions. Optional: restriction_type, locations"
   default     = {}
 }
 


### PR DESCRIPTION
This PR fixes a bug where setting one of the following properties will fail:

- default_cache_behavior
- geo_restriction

---

This is due to map(any) requiring all properties to be the same type, but they are not, some are arrays, booleans or ints.

---

The proposed fix replaces map(any) with any